### PR TITLE
fix: display errors when onFailed function is not implemented

### DIFF
--- a/packages/core/src/common/http/axioma/common.ts
+++ b/packages/core/src/common/http/axioma/common.ts
@@ -8,6 +8,7 @@ export function onSuccess(response: any, options?: RequestDefaultOptions) {
 export function onFailed(error: any, options?: RequestDefaultOptions) {
   if (typeof options?.onFailed === 'function')
     options?.onFailed(error)
+  console.error(error)
 }
 
 export function onFinally(options?: RequestDefaultOptions) {


### PR DESCRIPTION


## Description:

In this PR I Attempt to show errors when the function `OnFailed` is not implemented. 
Currently, if you did not implement the `OnFailed` function you cannot see any error. 

