### PR TITLE
ci: fail early with a clear message when the npm token cannot publish

### DIFF
--- a/.github/workflows/prerelease-alpha.yml
+++ b/.github/workflows/prerelease-alpha.yml
@@ -110,6 +110,27 @@ jobs:
       - name: Setup npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
 
+      # npm answers 404 to a PUT when the credential cannot write to the scope,
+      # so an auth failure is indistinguishable from a missing package at publish
+      # time. Resolve it here instead, before the build.
+      - name: Verify npm authentication
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "::error::NPM_TOKEN is empty: the secret is not reaching this job."
+            exit 1
+          fi
+          echo "Token length: ${#NPM_TOKEN}"
+
+          if ! npm whoami; then
+            echo "::error::The token cannot authenticate against the registry: expired, revoked, or not a valid npm token."
+            exit 1
+          fi
+
+          npm access list packages @fancy-crud \
+            || echo "::warning::Could not list the @fancy-crud packages. The token authenticates but may not carry write access to the scope."
+
       - name: setup pnpm config
         run: pnpm config set store-dir $PNPM_CACHE_FOLDER
 


### PR DESCRIPTION
The prerelease workflow fails at the publish step with:

    E404 Not Found - PUT https://registry.npmjs.org/@fancy-crud%2fbus

which reads as a missing package but is not one. @fancy-crud/bus has 91 published versions, the most recent being 2.2.28-beta.19, and every package under packages/ already declares publishConfig.access as public. For a package that exists and is public, npm answers 404 to a PUT when the credential lacks write access, so that it does not disclose what exists. The status is a masked 401 or 403.

Because the two cases are indistinguishable from the publish output, the diagnosis costs a full CI run each time. This adds a step that answers it directly, placed before the install and build so it fails in seconds:

- Reports whether the secret reaches the job at all, and its length.
- Runs npm whoami, failing with an explicit message when the token is expired, revoked or otherwise invalid.
- Lists the @fancy-crud packages, warning when the token authenticates but does not carry write access to the scope.

This is diagnostic only. It does not change how the publish is performed.