### PR TITLE
ci: push the release tag only after the publish succeeds

### DIFF
--- a/.github/workflows/prerelease-alpha.yml
+++ b/.github/workflows/prerelease-alpha.yml
@@ -82,9 +82,10 @@ jobs:
       - name: Run matic-release
         run: poetry run python scripts/release.py --ci
 
-      - name: Publish tag
-        run: git push --tags
-
+      # The tag is deliberately not pushed here. matic-release creates it
+      # locally, which is all toTag below needs, and pushing it before the
+      # publish succeeds makes the next run compute toTag == fromTag and skip
+      # publishing altogether. It is pushed by the push-tag job instead.
       - name: 'Get lastest tag'
         id: toTag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
@@ -154,11 +155,35 @@ jobs:
           pnpm build:p-vue3-toastify
           pnpm --filter "./packages/**" publish --no-git-checks --tag ${{ github.ref_name }}
 
+  push-tag:
+    runs-on: ubuntu-latest
+    needs:
+      - compute-new-tag-version
+      - publish
+    if: ${{ needs.compute-new-tag-version.outputs.fromTag != needs.compute-new-tag-version.outputs.toTag }}
+    steps:
+      - name: checkout code repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push the release tag
+        env:
+          TAG: ${{ needs.compute-new-tag-version.outputs.toTag }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "$TAG is already on the remote, nothing to push."
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
+
   generate-release:
     runs-on: ubuntu-latest
     needs:
       - compute-new-tag-version
       - publish
+      - push-tag
     if: ${{ needs.compute-new-tag-version.outputs.fromTag != needs.compute-new-tag-version.outputs.toTag }}
     steps:
       - name: checkout code repository


### PR DESCRIPTION
A failed publish used to leave the tag behind, which silently disabled the next release. The last two runs on beta show the full sequence:

- Run 142 tagged v2.2.28-beta.20, then failed to publish with a 404. The tag survived the failure and stayed on the remote.
- Run 143 computed toTag as v2.2.28-beta.20 again, matched it against fromTag, and skipped the publish job. A skipped job counts as success, so the run was green.

The result was a repository claiming v2.2.28-beta.20 was released, a registry with nothing under that version, and a green pipeline. The authentication check added in the previous change never ran either, since it lives inside the job that gets skipped.

The push is moved out of compute-new-tag-version and into a push-tag job that runs after publish. Removing it from the earlier job is safe because matic-release creates the tag locally, and the toTag step reads local tags, so the condition guarding publish still resolves exactly as before. Only the remote is left untouched until there is something on the registry to point at.

push-tag skips when the tag is already on the remote, so re-running a workflow does not fail on an existing tag. generate-release now waits for it, so git cliff and the GitHub release see the tag rather than creating their own.