### PR TITLE
fix: keep the repository npmrc when writing the publish token in CI

### DIFF
--- a/.github/workflows/prerelease-alpha.yml
+++ b/.github/workflows/prerelease-alpha.yml
@@ -108,8 +108,12 @@ jobs:
       - name: install pnpm
         run: npm i pnpm@10.18.2 -g
 
+      # Written to the user config, not to ./.npmrc: the repository ships its
+      # own .npmrc with shamefully-hoist, and overwriting it made the CI
+      # install resolve differently from a local one. Keeping the token out of
+      # the working tree also keeps it out of anything built from it.
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       # npm answers 404 to a PUT when the credential cannot write to the scope,
       # so an auth failure is indistinguishable from a missing package at publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,11 @@ jobs:
       - name: install pnpm
         run: npm i pnpm@8.15.7 -g
 
+      # Written to the user config, not to ./.npmrc: the repository ships its
+      # own .npmrc with shamefully-hoist, and overwriting it made the CI
+      # install resolve differently from a local one.
       - name: Setup npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: setup pnpm config
         run: pnpm config set store-dir $PNPM_CACHE_FOLDER


### PR DESCRIPTION
Both release workflows wrote the registry token with `> .npmrc`, which overwrites the .npmrc the repository already tracks. That file carries shamefully-hoist=true, and the step runs before `pnpm install`, so every CI install resolved its layout differently from a local one. A hoisting difference of that kind surfaces as a module that resolves on a contributor's machine and not on the runner, which is expensive to chase because nothing in the logs points at the cause.

The token now goes to the user config at ~/.npmrc. pnpm and npm both read it for authentication, so publishing and the authentication check are unaffected, while the project config stays intact. It also keeps the credential out of the working tree, and therefore out of anything built or archived from it.

Applied to prerelease-alpha.yml and release.yml, which carried the same line.